### PR TITLE
GETPARAM, STDICT, ISNULL value flow fixes

### DIFF
--- a/cp0.json
+++ b/cp0.json
@@ -37398,7 +37398,7 @@
         {
             "mnemonic": "PFXDICTGETQ",
             "doc": {
-                "category": "dict_special",
+                "category": "dict_prefix",
                 "description": "Looks up the unique prefix of _Slice_ `s` present in the prefix code dictionary represented by `Cell^?` `D` and `0 <= n <= 1023`. If found, the prefix of `s` is returned as `s'`, and the corresponding value (also a _Slice_) as `x`. The remainder of `s` is returned as a _Slice_ `s''`. If no prefix of `s` is a key in prefix code dictionary `D`, returns the unchanged `s` and a zero flag to indicate failure.",
                 "gas": "",
                 "fift": "PFXDICTGETQ"
@@ -37480,7 +37480,7 @@
         {
             "mnemonic": "PFXDICTGET",
             "doc": {
-                "category": "dict_special",
+                "category": "dict_prefix",
                 "description": "Similar to `PFXDICTGET`, but throws a cell deserialization failure exception on failure.",
                 "gas": "",
                 "fift": "PFXDICTGET"
@@ -37536,7 +37536,7 @@
         {
             "mnemonic": "PFXDICTGETJMP",
             "doc": {
-                "category": "dict_special",
+                "category": "dict_prefix",
                 "description": "Similar to `PFXDICTGETQ`, but on success `BLESS`es the value `x` into a _Continuation_ and transfers control to it as if by a `JMPX`. On failure, returns `s` unchanged and continues execution.",
                 "gas": "",
                 "fift": "PFXDICTGETJMP"
@@ -37562,7 +37562,7 @@
         {
             "mnemonic": "PFXDICTGETEXEC",
             "doc": {
-                "category": "dict_special",
+                "category": "dict_prefix",
                 "description": "Similar to `PFXDICTGETJMP`, but `EXEC`utes the continuation found instead of jumping to it. On failure, throws a cell deserialization exception.",
                 "gas": "",
                 "fift": "PFXDICTGETEXEC"
@@ -37629,7 +37629,7 @@
         {
             "mnemonic": "PFXDICTCONSTGETJMP",
             "doc": {
-                "category": "dict_special",
+                "category": "dict_prefix",
                 "description": "Combines `[n] DICTPUSHCONST` for `0 <= n <= 1023` with `PFXDICTGETJMP`.",
                 "gas": "",
                 "fift": "[ref] [n] PFXDICTCONSTGETJMP\n[ref] [n] PFXDICTSWITCH"

--- a/cp0.json
+++ b/cp0.json
@@ -4472,7 +4472,7 @@
             }
         },
         {
-            "mnemonic": "ADDRSHIFTMOD",
+            "mnemonic": "ADDRSHIFTMOD_VAR",
             "doc": {
                 "category": "arithm_div",
                 "description": "",

--- a/cp0.json
+++ b/cp0.json
@@ -8086,7 +8086,7 @@
             "doc": {
                 "category": "arithm_div",
                 "description": "",
-                "gas": "26",
+                "gas": "34",
                 "fift": "[tt+1] LSHIFT#DIVC"
             },
             "bytecode": {

--- a/cp0.json
+++ b/cp0.json
@@ -10891,9 +10891,9 @@
                 "fift": "[tt+1] QRSHIFT#MOD"
             },
             "bytecode": {
-                "doc_opcode": "A93Ctt",
-                "tlb": "#A93C tt:uint8",
-                "prefix": "A93C",
+                "doc_opcode": "B7A93Ctt",
+                "tlb": "#B7A93C tt:uint8",
+                "prefix": "B7A93C",
                 "operands": [
                     {
                         "name": "t",
@@ -10940,9 +10940,9 @@
                 "fift": "[tt+1] QRSHIFTR#MOD"
             },
             "bytecode": {
-                "doc_opcode": "A93Dtt",
-                "tlb": "#A93D tt:uint8",
-                "prefix": "A93D",
+                "doc_opcode": "B7A93Dtt",
+                "tlb": "#B7A93D tt:uint8",
+                "prefix": "B7A93D",
                 "operands": [
                     {
                         "name": "t",

--- a/cp0.json
+++ b/cp0.json
@@ -3495,7 +3495,7 @@
                         "internal": true
                     },
                     {
-                        "name": "s",
+                        "name": "c",
                         "loader": "subslice",
                         "loader_args": {
                             "bits_length_var": "x",
@@ -3549,7 +3549,7 @@
                         "internal": true
                     },
                     {
-                        "name": "s",
+                        "name": "c",
                         "loader": "subslice",
                         "loader_args": {
                             "bits_length_var": "x",

--- a/cp0.json
+++ b/cp0.json
@@ -7140,10 +7140,18 @@
                 "fift": "MULRSHIFT#MOD"
             },
             "bytecode": {
-                "doc_opcode": "A9BC",
-                "tlb": "#A9BC",
+                "doc_opcode": "A9BCtt",
+                "tlb": "#A9BC tt:uint8",
                 "prefix": "A9BC",
-                "operands": []
+                "operands": [
+                  {
+                    "name": "t",
+                    "loader": "uint",
+                    "loader_args": {
+                      "size": 8
+                    }
+                  }
+                ]
             },
             "value_flow": {
                 "doc_stack": "x y - q=floor(x*y/2^(tt+1)) r=xy-q*2^(tt+1)",
@@ -7181,10 +7189,18 @@
                 "fift": "MULRSHIFTR#MOD"
             },
             "bytecode": {
-                "doc_opcode": "A9BD",
-                "tlb": "#A9BD",
+                "doc_opcode": "A9BDtt",
+                "tlb": "#A9BD tt:uint8",
                 "prefix": "A9BD",
-                "operands": []
+                "operands": [
+                  {
+                    "name": "t",
+                    "loader": "uint",
+                    "loader_args": {
+                      "size": 8
+                    }
+                  }
+                ]
             },
             "value_flow": {
                 "doc_stack": "x y - q=round(x*y/2^(tt+1)) r=xy-q*2^(tt+1)",
@@ -7222,10 +7238,18 @@
                 "fift": "MULRSHIFTC#MOD"
             },
             "bytecode": {
-                "doc_opcode": "A9BE",
-                "tlb": "#A9BE",
+                "doc_opcode": "A9BEtt",
+                "tlb": "#A9BE tt:uint8",
                 "prefix": "A9BE",
-                "operands": []
+                "operands": [
+                  {
+                    "name": "t",
+                    "loader": "uint",
+                    "loader_args": {
+                      "size": 8
+                    }
+                  }
+                ]
             },
             "value_flow": {
                 "doc_stack": "x y - q=ceil(x*y/2^(tt+1)) r=xy-q*2^(tt+1)",

--- a/cp0.json
+++ b/cp0.json
@@ -1316,7 +1316,7 @@
                         {
                             "type": "simple",
                             "name": "x",
-                            "value_types": ["Integer"]
+                            "value_types": ["Integer", "Null"]
                         }
                     ]
                 },
@@ -28494,7 +28494,7 @@
                         {
                             "type": "simple",
                             "name": "D",
-                            "value_types": ["Slice", "Null"]
+                            "value_types": ["Cell", "Null"]
                         },
                         {
                             "type": "simple",
@@ -38358,7 +38358,7 @@
                         {
                             "type": "simple",
                             "name": "x",
-                            "value_types": ["Integer"]
+                            "value_types": ["Integer", "Slice"]
                         }
                     ]
                 }


### PR DESCRIPTION
1. ISNULL instruction should definitely accept "Null" as possible arg
2. STDICT should accept "Cell", not "Slice" since docs.ton org clearly describes this instruction as: "Stores dictionary D into Builder b, returing the resulting Builder b'. In other words, if D is a cell..."
3. GETPARAM should accept "Slice" since it "Returns the i-th parameter from the Tuple provided at c7..." and c7 contains field `myself` which is `Address of this smart contract` (which is Slice)
source https://docs.ton.org/v3/documentation/tvm/tvm-initialization#control-register-c7